### PR TITLE
Fix showPersonAtIndex

### DIFF
--- a/src/main/java/seedu/address/model/person/StudentIdMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/person/StudentIdMatchesPredicate.java
@@ -1,4 +1,26 @@
 package seedu.address.model.person;
 
-public class StudentIdMatchesPredicate {
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s {@code StudentId} matches the given student ID.
+ */
+public class StudentIdMatchesPredicate implements Predicate<Person> {
+    private final StudentId studentId;
+
+    public StudentIdMatchesPredicate(StudentId studentId) {
+        this.studentId = studentId;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getStudentId().equals(studentId);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof StudentIdMatchesPredicate
+                && studentId.equals(((StudentIdMatchesPredicate) other).studentId));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -13,15 +13,14 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.StudentIdMatchesPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 /**
@@ -147,8 +146,7 @@ public class CommandTestUtil {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
 
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
-        final String[] splitName = person.getName().fullName.split("\\s+");
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.updateFilteredPersonList(new StudentIdMatchesPredicate(person.getStudentId()));
 
         assertEquals(1, model.getFilteredPersonList().size());
     }


### PR DESCRIPTION
Replace name-based filtering with StudentId-based filtering to ensure
unique person identification in tests. StudentId is the primary unique
identifier, while names may have duplicates.