### PR TITLE
Update codecov link to show tP coverage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@
 
 # LambdaLab
 
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
-[![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
+[![CI Status](https://github.com/AY2526S1-CS2103T-T09-3/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2526S1-CS2103T-T09-3/tp/actions)
+[![codecov](https://codecov.io/gh/AY2526S1-CS2103T-T09-3/tp/branch/master/graph/badge.svg)](https://codecov.io/gh/AY2526S1-CS2103T-T09-3/tp)
 
 ![Ui](images/Ui.png)
 


### PR DESCRIPTION
It was previously showing AB3 code coverage, not our tP version.